### PR TITLE
implement better paginating and limit using jdbc on a mysql database

### DIFF
--- a/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
+++ b/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
@@ -50,7 +50,7 @@ public class HandleReverseLookupResource {
 	 * 
 	 * All parameters are treated as such search fields except for a few special ones:
 	 * <ul>
-	 * <li><em>limit:</em> Limits the maximum number of results to return. The default limit for Solr queries is 1000; there is no default for SQL. Limits for Solr larger than 1000 can be specified.</li>
+	 * <li><em>limit:</em> Limits the maximum number of results to return. The default limit for Solr queries is 1000; The max limit for SQL is 100000. The default is 1000 SQL. Limits for Solr larger than 1000 can be specified.</li>
 	 * <li><em>page (SQL only):</em> Skip the given number of results, enabling pagination if combined with a limit. Limits the maximum number of results to return.</li>
 	 * <li><em>enforcesql:</em> If both SQL and Solr are configured for searching, Solr takes precedence by default. If enforcesql is set to true, SQL will be used instead of Solr.
 	 * <li><em>retrieverecords (SQL only):</em> Do not only return Handle names, but full record contents. Note: This only works if only one search field is given.</li>
@@ -189,7 +189,7 @@ public class HandleReverseLookupResource {
 	 * @param parameters A map of all search fields. Should not contain special parameters such as 'limit' or 'enforcesql'.
 	 * @param limit
 <<<<<<< HEAD
-	 *            SQL query limit. May be null, but will then be set to 1000 as default. Can never be higher than 10000.
+	 *            SQL query limit. May be null, but will then be set to 1000 as default. Can never be higher than 100000.
 =======
 	 *            SQL query limit. May be null.
 >>>>>>> master
@@ -213,6 +213,9 @@ public class HandleReverseLookupResource {
 			connection = dataSource.getConnection();
 			StringBuffer sb = new StringBuffer();
 			List<String> stringParams = new LinkedList<String>();
+			// set limit to default of 1000 if nothing is set 
+			if (limit == null)
+				limit = 1000;
 			if (parameters.size() == 1) {
 				// Simple query, no joins
 				String key = parameters.keySet().iterator().next();
@@ -232,11 +235,9 @@ public class HandleReverseLookupResource {
 						sb.append(" on table_" + (tableIndex - 1) + ".handle=table_" + tableIndex + ".handle");
 					tableIndex++;
 				}
-				if (limit != null)
-					sb.append(" limit " + Math.min(limit, 100000));
-				else sb.append(" limit 1000");
+				sb.append(" limit " + Math.min(limit, 100000));
 				if (page != null)
-					sb.append(" offset " + page);
+					sb.append(" offset " + page*limit);
 			}
 			// Now fill statement with stringParams
 			statement = connection.prepareStatement(sb.toString());
@@ -319,9 +320,9 @@ public class HandleReverseLookupResource {
 			stringParams.add(modvalue);
 		}
 		if (limit != null)
-			sb.append(" limit " + limit);
+			sb.append(" limit " + Math.min(limit, 100000));
 		if (page != null)
-			sb.append(" offset " + page);
+			sb.append(" offset " + page*limit);
 		if (retrieveRecords)
 			sb.append(") subtable on allvalues.handle=subtable.subhandle"); // close sub-select; limit/page be applied to it rather than the outer select
 	}


### PR DESCRIPTION
tested:
* default of max 1000 handles returned when no limit set
```
$  curl -s -u "$user:$password" "https://$fqdn:8001/hrls/handles?URL=*" | python -m json.tool | sort | wc -l
1002
```
* limit the maximum to 100.000 handles:
```
$  curl -s -u "$user:$password" "https://$fqdn:8001/hrls/handles?URL=*&limit=200000" | python -m json.tool | sort | wc -l
100002
```

* 20 handles returned when asked:
```
$  curl -s -u "$user:$password" "https://$fqdn:8001/hrls/handles?URL=*&limit=20" | python -m json.tool | sort 
[
]
    "841/00c5a924-9cd4-11e5-8a71-040091643bd0", 
    "841/01184526-9cd4-11e5-8fea-040091643bd0", 
    "841/017e14b4-9cd4-11e5-8f00-040091643bd0", 
    "841/01cf5860-9cd4-11e5-ba16-040091643bd0", 
    "841/0230e558-9cd4-11e5-a1c6-040091643bd0", 
    "841/0243a886-7c60-11e4-a748-780dd91bf992", 
    "841/02617ca8-b250-11e6-acf4-5254000df0ed", 
    "841/02b39e64-f3d6-11e4-a518-5254000df0ed", 
    "841/04334470-9cd1-11e5-a431-040091643bd0", 
    "841/0481380a-f3d1-11e4-a4aa-5254000df0ed", 
    "841/0a2b604e-ab42-11e6-8687-04040a6400c1", 
    "841/0affcfae-7c60-11e4-a748-780dd91bf992", 
    "841/0b2afb68-9cd3-11e5-afc8-040091643bd0", 
    "841/0b30e82a-1dfe-11e4-90a0-14feb56120b9", 
    "841/0b53b861-d0b2-4fee-899a-9b04b3ad5fce", 
    "841/0e1aeae4-9cd4-11e5-8771-040091643bd0", 
    "841/0e6beb06-9cd4-11e5-9ec3-040091643bd0", 
    "841/0e75ded0-23d0-11e6-987a-04040a6400cb", 
    "841/0ecc3128-9cd4-11e5-ab2e-040091643bd0", 
    "841/0f032440-1dfe-11e4-90a0-14feb56120b9"
```
* get first 10 handles using paginate:
```
$  curl -s -u "$user:$password" "https://$fqdn:8001/hrls/handles?URL=*&limit=10&page=0" | python -m json.tool | sort 
[
]
    "841/00c5a924-9cd4-11e5-8a71-040091643bd0", 
    "841/01184526-9cd4-11e5-8fea-040091643bd0", 
    "841/017e14b4-9cd4-11e5-8f00-040091643bd0", 
    "841/01cf5860-9cd4-11e5-ba16-040091643bd0", 
    "841/0230e558-9cd4-11e5-a1c6-040091643bd0", 
    "841/0243a886-7c60-11e4-a748-780dd91bf992", 
    "841/02617ca8-b250-11e6-acf4-5254000df0ed", 
    "841/02b39e64-f3d6-11e4-a518-5254000df0ed", 
    "841/04334470-9cd1-11e5-a431-040091643bd0", 
    "841/0481380a-f3d1-11e4-a4aa-5254000df0ed"
```
* get second 10 handles using paginate:
```
$  curl -s -u "$user:$password" "https://$fqdn:8001/hrls/handles?URL=*&limit=10&page=1" | python -m json.tool | sort 
[
]
    "841/0a2b604e-ab42-11e6-8687-04040a6400c1", 
    "841/0affcfae-7c60-11e4-a748-780dd91bf992", 
    "841/0b2afb68-9cd3-11e5-afc8-040091643bd0", 
    "841/0b30e82a-1dfe-11e4-90a0-14feb56120b9", 
    "841/0b53b861-d0b2-4fee-899a-9b04b3ad5fce", 
    "841/0e1aeae4-9cd4-11e5-8771-040091643bd0", 
    "841/0e6beb06-9cd4-11e5-9ec3-040091643bd0", 
    "841/0e75ded0-23d0-11e6-987a-04040a6400cb", 
    "841/0ecc3128-9cd4-11e5-ab2e-040091643bd0", 
    "841/0f032440-1dfe-11e4-90a0-14feb56120b9"
```
* get only matching handles. Even if the limit is more (limit =100.000, but only 27 match):
```
$  curl -s -u "$user:$password" "https://$fqdn:8001/hrls/handles?URL=www.test.com*&limit=100000&page=0" | python -m json.tool | sort 
[
]
    "841/124c50b8-b30c-11e6-b3ab-5254000df0ed", 
    "841/3bb67ba6-bdf5-11e6-98fb-5254000df0ed", 
    "841/3d4f875a-8c86-11e6-a041-04040a6400c1", 
    "841/5b316a1a-c50a-11e6-ad09-fa163ed79f1d", 
    "841/70bbceba-bdf4-11e6-b93c-5254000df0ed", 
    "841/8b78fb0e-aa4b-11e6-8e92-5254000df0ed", 
    "843/2e8f473a-ffc0-11e5-b9c3-5254000df0ed", 
    "846/012e5e8e-2400-11e6-99ca-04040a6400d7", 
    "846/101172be-69f2-11e6-85fd-fa163efdf672", 
    "846/42582834-c50b-11e6-a54d-fa163edb14ff", 
    "846/4a20d7f0-7669-11e6-bf94-0200c0a809d6", 
    "846/586bacfc-2c83-11e6-be58-fa163e8d0163", 
    "846/5cae4d12-7664-11e6-ac61-fa163efdf672", 
    "846/5f1f9848-69f4-11e6-bbe1-fa163e38303e", 
    "846/61024e44-a987-11e6-9b1d-040091643b25", 
    "846/6f83d2f8-23f4-11e6-bb96-fa163e8d0163", 
    "846/7a0faa10-2743-11e6-b945-04040a64000d", 
    "846/b7653dc4-8c5d-11e6-8783-04040a6400c3", 
    "846/ba0797fa-2cb0-11e6-a2b4-fa163e3735eb", 
    "846/bc4a1f9e-69f3-11e6-8970-fa163efdf672", 
    "846/c34e3d70-9072-11e6-b8f5-04040a64004a", 
    "846/dc487e82-2743-11e6-aec8-04040a64000d", 
    "846/e158e5c6-23ef-11e6-8eeb-fa163ec7338b", 
    "846/f01f7f16-ab0d-11e6-af9a-040091643b25", 
    "846/f84d7930-2701-11e6-aae1-04040a64008f"
```
* work if only page is filled in:
```
$  curl -s -u "$user:$password" "https://$fqdn:8001/hrls/handles?URL=*&page=0" | python -m json.tool | sort | wc -l
1002
```