### PR TITLE
retrieve only handles which match a specific prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ curl -u "username:password" https://your.server:port/hrls/ping
 
 curl -u "username:password" https://your.server:port/hrls/handles?URL=*
 
+curl -u "username:password" https://your.server:port/hrls/handles/11112?URL=*
+
 curl -u "username:password" https://your.server:port/hrls/handles?URL=http://www.test.com&EMAIL=mail@test.com
 
 curl -u "username:password" https://your.server:port/hrls/handles?URL=*&limit=20

--- a/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
+++ b/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
@@ -44,22 +44,6 @@ public class HandleReverseLookupResource {
 		return "OK\n";
 	}
 	
-	/**
-	 * Searches over Handles via their record information. The method will return a list of all Handles whose records match all of the supplied parameters.
-	 * The parameters are not a fixed set; the usual 'URL' field is a good example as this establishes what is usually understood as Handle reverse-lookup: Get to a Handle given a target URL. 
-	 * However, any fields that are available from the Handle SQL storage or a Solr index can be used.
-	 * 
-	 * All parameters are treated as such search fields except for a few special ones:
-	 * <ul>
-	 * <li><em>limit:</em> Limits the maximum number of results to return. The default limit for Solr queries is 1000; The max limit for SQL is 100000. The default is 1000 SQL. Limits for Solr larger than 1000 can be specified.</li>
-	 * <li><em>page (SQL only):</em> Skip the given number of results, enabling pagination if combined with a limit. Limits the maximum number of results to return.</li>
-	 * <li><em>enforcesql:</em> If both SQL and Solr are configured for searching, Solr takes precedence by default. If enforcesql is set to true, SQL will be used instead of Solr.
-	 * <li><em>retrieverecords (SQL only):</em> Do not only return Handle names, but full record contents. Note: This only works if only one search field is given.</li>
-	 * </dl>
-	 * 
-	 * @param info A UriInfo object carrying, among other things, the URL parameters. See above for explanations.
-	 * @return A simple list of Handles (just Handle names, no record excerpts, even not for the fields searched).
-	 */
 	@GET
 	@Path("handles")
 	@Produces("application/json")
@@ -78,6 +62,22 @@ public class HandleReverseLookupResource {
 		return result;
 	}
 
+	/**
+	 * Searches over Handles via their record information. The method will return a list of all Handles whose records match all of the supplied parameters.
+	 * The parameters are not a fixed set; the usual 'URL' field is a good example as this establishes what is usually understood as Handle reverse-lookup: Get to a Handle given a target URL. 
+	 * However, any fields that are available from the Handle SQL storage or a Solr index can be used.
+	 * 
+	 * All parameters are treated as such search fields except for a few special ones:
+	 * <ul>
+	 * <li><em>limit:</em> Limits the maximum number of results to return. The default limit for Solr queries is 1000; The max limit for SQL is 100000. The default is 1000 SQL. Limits for Solr larger than 1000 can be specified.</li>
+	 * <li><em>page (SQL only):</em> Skip the given number of results, enabling pagination if combined with a limit. Limits the maximum number of results to return.</li>
+	 * <li><em>enforcesql:</em> If both SQL and Solr are configured for searching, Solr takes precedence by default. If enforcesql is set to true, SQL will be used instead of Solr.
+	 * <li><em>retrieverecords (SQL only):</em> Do not only return Handle names, but full record contents. Note: This only works if only one search field is given.</li>
+	 * </dl>
+	 * 
+	 * @param info A UriInfo object carrying, among other things, the URL parameters. See above for explanations.
+	 * @return A simple list of Handles (just Handle names, no record excerpts, even not for the fields searched).
+	 */
 	public Response search(@PathParam("prefix") String prefix, @Context UriInfo info) {
 		MultivaluedMap<String, String> params = info.getQueryParameters();
 		ReverseLookupConfig configuration = ReverseLookupConfig.getInstance();

--- a/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
+++ b/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
@@ -54,7 +54,7 @@ public class HandleReverseLookupResource {
 	}
 
 	@GET
-	@Path("handles/{prefix}")
+	@Path("handles/{prefix: \\d{2}[0-9a-zA-Z.]*}")
 	@Produces("application/json")
 	public Response searchPrefix(@PathParam("prefix") String prefix, @Context UriInfo info) {
 		Response result;


### PR DESCRIPTION
implement searching for handles where you can only find handles for a specific prefix:

- test to find all handles within the database:
```
$ curl -s -u "<user>:<password>" "https://fqdn:8007/hrls/handles?URL=www.test.com" | python -m json.tool
[
    "21.T12995/23AE701C-90AF-11E7-B655-0242AC160003", 
    "21.T12995/254B99B0-4F49-11E7-AC34-040091643B7D", 
    "21.T12995/52DCF3BC-6D42-11E7-9A99-0242AC010003", 
    "21.T12995/6B056B42-7524-11E7-9857-0242AC010003", 
    "21.T12995/6F3E2748-A1D0-11E7-A72A-04060A64000C", 
    "21.T12995/84E2CF9C-9DFA-11E7-8366-04060A6400B9", 
    "21.T12995/BBDAEB78-4F59-11E7-849E-040091643B7D", 
    "21.T12995/D32AF060-4CEE-11E7-9866-040091643B7D", 
    "21.T12995/ED1E507C-7A7D-11E7-9F37-0242AC160003", 
    "21.T12995/FDAF4DE4-4C4A-11E7-924A-040091643B2D", 
    "21.T12996/14952538-4C4B-11E7-AC74-040091643B7D", 
    "21.T12996/2DECF466-4D13-11E7-A770-040091643B2D", 
    "21.T12996/2F7C640E-512A-11E7-9794-5254000DF0ED", 
    "21.T12996/34431950-9E01-11E7-8388-04060A6400BE", 
    "21.T12996/51884456-831A-11E7-831C-040091643BAF", 
    "21.T12996/57AA707A-831A-11E7-AC5C-040091643BAF", 
    "21.T12996/5F4A27CC-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/613A02E0-9F7B-11E7-8765-04060A6400BE", 
    "21.T12996/65E017D0-831A-11E7-8B2D-040091643BAF", 
    "21.T12996/83BC3596-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/97076472-5128-11E7-91AF-5254000DF0ED", 
    "21.T12996/AAD1CD80-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/F8FC13CA-5129-11E7-A1A8-5254000DF0ED"
]

$ curl -s -u "<user>::<password>" "https://fqdn:8007/hrls/handles/?URL=www.test.com" | python -m json.tool
[
    "21.T12995/23AE701C-90AF-11E7-B655-0242AC160003", 
    "21.T12995/254B99B0-4F49-11E7-AC34-040091643B7D", 
    "21.T12995/52DCF3BC-6D42-11E7-9A99-0242AC010003", 
    "21.T12995/6B056B42-7524-11E7-9857-0242AC010003", 
    "21.T12995/6F3E2748-A1D0-11E7-A72A-04060A64000C", 
    "21.T12995/84E2CF9C-9DFA-11E7-8366-04060A6400B9", 
    "21.T12995/BBDAEB78-4F59-11E7-849E-040091643B7D", 
    "21.T12995/D32AF060-4CEE-11E7-9866-040091643B7D", 
    "21.T12995/ED1E507C-7A7D-11E7-9F37-0242AC160003", 
    "21.T12995/FDAF4DE4-4C4A-11E7-924A-040091643B2D", 
    "21.T12996/14952538-4C4B-11E7-AC74-040091643B7D", 
    "21.T12996/2DECF466-4D13-11E7-A770-040091643B2D", 
    "21.T12996/2F7C640E-512A-11E7-9794-5254000DF0ED", 
    "21.T12996/34431950-9E01-11E7-8388-04060A6400BE", 
    "21.T12996/51884456-831A-11E7-831C-040091643BAF", 
    "21.T12996/57AA707A-831A-11E7-AC5C-040091643BAF", 
    "21.T12996/5F4A27CC-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/613A02E0-9F7B-11E7-8765-04060A6400BE", 
    "21.T12996/65E017D0-831A-11E7-8B2D-040091643BAF", 
    "21.T12996/83BC3596-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/97076472-5128-11E7-91AF-5254000DF0ED", 
    "21.T12996/AAD1CD80-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/F8FC13CA-5129-11E7-A1A8-5254000DF0ED"
]
```
- test to find all handles within the database for prefix 21.T12995:
```
$ curl -s -u "<user>::<password>" "https://fqdn:8007/hrls/handles/21.T12995?URL=www.test.com" | python -m json.tool
[
    "21.T12995/23AE701C-90AF-11E7-B655-0242AC160003", 
    "21.T12995/254B99B0-4F49-11E7-AC34-040091643B7D", 
    "21.T12995/52DCF3BC-6D42-11E7-9A99-0242AC010003", 
    "21.T12995/6B056B42-7524-11E7-9857-0242AC010003", 
    "21.T12995/6F3E2748-A1D0-11E7-A72A-04060A64000C", 
    "21.T12995/84E2CF9C-9DFA-11E7-8366-04060A6400B9", 
    "21.T12995/BBDAEB78-4F59-11E7-849E-040091643B7D", 
    "21.T12995/D32AF060-4CEE-11E7-9866-040091643B7D", 
    "21.T12995/ED1E507C-7A7D-11E7-9F37-0242AC160003", 
    "21.T12995/FDAF4DE4-4C4A-11E7-924A-040091643B2D"
]
```
- test to find all handles within the database for prefix 21.T12996:
```
$ curl -s -u "<user>::<password>" "https://fqdn:8007/hrls/handles/21.T12996?URL=www.test.com" | python -m json.tool
[
    "21.T12996/14952538-4C4B-11E7-AC74-040091643B7D", 
    "21.T12996/2DECF466-4D13-11E7-A770-040091643B2D", 
    "21.T12996/2F7C640E-512A-11E7-9794-5254000DF0ED", 
    "21.T12996/34431950-9E01-11E7-8388-04060A6400BE", 
    "21.T12996/51884456-831A-11E7-831C-040091643BAF", 
    "21.T12996/57AA707A-831A-11E7-AC5C-040091643BAF", 
    "21.T12996/5F4A27CC-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/613A02E0-9F7B-11E7-8765-04060A6400BE", 
    "21.T12996/65E017D0-831A-11E7-8B2D-040091643BAF", 
    "21.T12996/83BC3596-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/97076472-5128-11E7-91AF-5254000DF0ED", 
    "21.T12996/AAD1CD80-81A7-11E7-8B42-08002716DB84", 
    "21.T12996/F8FC13CA-5129-11E7-A1A8-5254000DF0ED"
]
````

It has been implemented for the normal search. It does NOT work when using the parameter: `retrieverecords`