### PR TITLE
add 4 tests to check for prefix inclusion in path to search

### DIFF
--- a/tests/testHrlsCmd/hrlsintgtest.py
+++ b/tests/testHrlsCmd/hrlsintgtest.py
@@ -499,3 +499,62 @@ class HrlsIntegrationTests(unittest.TestCase):
             'HS_SECKEY', search_result.content,
             'search handle by existing key value gives back HS_SECKEY response')
 
+    def test_search_handle_by_prefix_existing_key_value_1(self):
+        """Test that search by ['prefix','URL=http://www.test_hrls_check.com/*'] returns 1000 handles."""
+        limit = 1000
+        search_array=['URL=http://www.test_hrls_check.com/*']
+        search_result = execute_curl(self.handle_server_url+'/hrls/handles/'+self.prefix, self.username, self.password, search_array, self.https_verify)
+        self.assertEqual(
+            search_result.status_code, 200,
+            'search hrls by existing prefix,key value returns unexpected status')
+        search_result_list = json.loads(search_result.content)
+        json_check_list = []
+        for x in xrange(1, limit+1):
+            counter = "%06d" % x
+            json_check_list.append(self.prefix+'/HRLS_CHECK_HANDLE_'+counter)
+        set1 = set(search_result_list)
+        set2 = set(json_check_list)
+        self.assertEqual(
+            set1, set2,
+            'search handle by prefix,existing key value returns unexpected response')
+
+    def test_search_handle_by_prefix_existing_key_value_2(self):
+        """Test that search by ['prefix;xyz','URL=http://www.test_hrls_check.com/*'] returns 1000 handles."""
+        limit = 1000
+        search_array=['URL=http://www.test_hrls_check.com/*']
+        search_result = execute_curl(self.handle_server_url+'/hrls/handles/'+self.prefix+';xyz', self.username, self.password, search_array, self.https_verify)
+        self.assertEqual(
+            search_result.status_code, 200,
+            'search hrls by existing prefix;xyz,key value returns unexpected status')
+        search_result_list = json.loads(search_result.content)
+        json_check_list = []
+        for x in xrange(1, limit+1):
+            counter = "%06d" % x
+            json_check_list.append(self.prefix+'/HRLS_CHECK_HANDLE_'+counter)
+        set1 = set(search_result_list)
+        set2 = set(json_check_list)
+        self.assertEqual(
+            set1, set2,
+            'search handle by prefix;xyz,existing key value returns unexpected response')
+
+    def test_search_handle_by_prefix_existing_key_value_3(self):
+        """Test that search by ['prefixi','URL=http://www.test_hrls_check.com/*'] returns no handles."""
+        limit = 1000
+        search_array=['URL=http://www.test_hrls_check.com/*']
+        search_result = execute_curl(self.handle_server_url+'/hrls/handles/'+self.prefix+'i', self.username, self.password, search_array, self.https_verify)
+        self.assertEqual(
+            search_result.status_code, 200,
+            'search hrls by existing prefixi,key value returns unexpected status')
+        self.assertEqual(
+            search_result.content, '[]',
+            'search handle by prefixi,existing key value returns unexpected response')
+
+    def test_search_handle_by_prefix_existing_key_value_4(self):
+        """Test that search by ['prefix i','URL=http://www.test_hrls_check.com/*'] returns error."""
+        limit = 1000
+        search_array=['URL=http://www.test_hrls_check.com/*']
+        search_result = execute_curl(self.handle_server_url+'/hrls/handles/'+self.prefix+' i', self.username, self.password, search_array, self.https_verify)
+        self.assertEqual(
+            search_result.status_code, 404,
+            'search hrls by existing prefix i,key value returns unexpected status')
+


### PR DESCRIPTION
Tested:
```
$ ./testHrlsCmd.py -test hrls
Test hrls Script
Test that ping works. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/000001'] returns specific handle. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/000001','HS_ADMIN=*'] returns specific handle. ... ok
Test that search by ['HS_ADMIN=*','URL=http://www.test_hrls_check.com/000001'] returns specific handle. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*'] returns 1000 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','limit=10000'] returns 10000 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','limit=100000'] returns 100000 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','limit=200000'] returns 100000 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','page=0'] returns first 1000 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','page=1'] returns second 1000 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','page=2'] returns third 1000 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','page=0','limit=10'] returns first 10 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','page=1','limit=10'] returns second 10 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','limit=10','page=0'] returns first 10 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','limit=10','page=1'] returns second 10 handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/000001','retrieverecords=true'] returns all records for that handle. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/00000*','retrieverecords=true','limit=9'] returns all records for those handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/*','retrieverecords=true','limit=100000'] returns all records for those handles. ... ok
Test that search by ['URL=http://www.test_hrls_check.com/000001','retrieverecords=true'] returns all records for that handle except HS_SECKEY. ... ok
Test that search by ['URL=my_unknown_handle_url'] returns no matching handle. ... ok
Test that search by ['URL=my_unknown_handle_url','HS_ADMIN=*'] returns no matching handle. ... ok
Test that search by ['HS_ADMIN=*','URL=my_unknown_handle_url'] returns no matching handle. ... ok
Test that search by ['prefix','URL=http://www.test_hrls_check.com/*'] returns 1000 handles. ... ok
Test that search by ['prefix;xyz','URL=http://www.test_hrls_check.com/*'] returns 1000 handles. ... ok
Test that search by ['prefixi','URL=http://www.test_hrls_check.com/*'] returns no handles. ... ok
Test that search by ['prefix i','URL=http://www.test_hrls_check.com/*'] returns error. ... ok
Test that search by ['HS_SECKEY=*'] returns specific message. ... ok
Test that search by ['HS_SECKEY=*','URL=*'] returns specific message. ... ok
Test that search by ['URL=*','HS_SECKEY=*'] returns specific message. ... ok

----------------------------------------------------------------------
Ran 29 tests in 15.415s

OK
```
The test with prefix are new. It uses the prefix defined in the credentials file.
* 1st matches
 * 2nd matches too but only until the ';'
 * 3rd does not match
 * 4th gives an error because of the space in the URL