### PR TITLE
Add "mvn clean" to README.md for cases where you build a new version …

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ B2HANDLE-HRLS provides a Java servlet that will enable reverse-lookup and search
 
 This is a Maven-enabled project. To build a .war file, install [Apache Maven](https://maven.apache.org) and then call:
 ```
+$ mvn clean
 $ mvn compile
 $ mvn war:war
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ mvn war:war
 ```
 The .war file will be under subdirectory "target". 
 
-## How to deploy (using embedded Handle System v8 Jetty)
+## How to deploy (using embedded Handle System v8 (or higher) Jetty)
 
 To deploy the servlet .war in the embedded jetty, copy it to your-instance-directory/webapps.
 The servlet also needs configuration. Most importantly, the servlet requires an environmental variable **HANDLE_SVR** which should point to the Handle server instance's home directory from which the servlet will load its configuration file.


### PR DESCRIPTION
Add "mvn clean" to README.md for cases where you build a new version of the servlet. This helps when an old version exists.

This is implemented because in this version f.i. log4j is a newer version and otherwise old versions will also be installed/included in the war file