### PR TITLE
Bugfix: Implement prefix as search parameter when "retrieverecords=true".

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,5 +100,10 @@
   		<artifactId>c3p0</artifactId>
   		<version>[0.9.5.3,)</version>
   	</dependency>
+  	<dependency>
+  		<groupId>javax.servlet</groupId>
+  		<artifactId>javax.servlet-api</artifactId>
+  		<version>4.0.1</version>
+  	</dependency>
   </dependencies>
 </project>

--- a/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
+++ b/src/de/dkrz/handlereverselookupservlet/HandleReverseLookupResource.java
@@ -401,8 +401,13 @@ public class HandleReverseLookupResource {
 	private void makeSearchSubquery(String prefix, String key, List<String> list, StringBuffer sb,
 			List<String> stringParams, Integer limit, Integer page, boolean retrieveRecords) {
 		if (retrieveRecords) {
-			sb.append(
+			if (prefix != null) {
+				sb.append("select handle, type, data from handles as allvalues inner join ");
+				sb.append(" (select handle as subhandle from handles where handle like '" + prefix + "%' and type=?");
+			} else {
+				sb.append(
 					"select handle, type, data from handles as allvalues inner join (select handle as subhandle from handles where type=?");
+			}
 		} else {
 			if (prefix != null) {
 				sb.append("select handle from handles where handle like '" + prefix + "%'");

--- a/tests/testHrlsCmd/hrlsintgtest.py
+++ b/tests/testHrlsCmd/hrlsintgtest.py
@@ -555,6 +555,50 @@ class HrlsIntegrationTests(unittest.TestCase):
             search_result.status_code, 404,
             'search hrls by existing prefix i,key value returns unexpected status')
         
+    def test_search_handle_by_prefix_existing_key_value_5(self):
+        """Test that search by ['prefix','URL=http://www.test_hrls_check.com/000001','retrieverecords=true'] returns all records for that handle."""
+        search_array=['URL=http://www.test_hrls_check.com/000001','retrieverecords=true']
+        search_result = execute_curl(self.handle_server_url+'/hrls/handles', self.username, self.password, search_array, self.https_verify)
+        self.assertEqual(
+            search_result.status_code, 200,
+            'search hrls by existing key value returns unexpected status')
+        search_result_list = json.loads(search_result.content)
+        self.assertEqual(
+            search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001'][0]['type'], 'URL',
+            'search handle by existing key value returns unexpected response')
+        self.assertEqual(
+            search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001'][0]['value'], 'http://www.test_hrls_check.com/000001',
+            'search handle by existing key value returns unexpected response')
+        self.assertEqual(
+            search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001'][1]['type'], 'EMAIL',
+            'search handle by existing key value returns unexpected response')
+        self.assertEqual(
+            search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001'][1]['value'], 'test_hrls_000001@test_hrls_check.com',
+            'search handle by existing key value returns unexpected response')
+        self.assertEqual(
+            search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001'][2]['type'], 'TEXT',
+            'search handle by existing key value returns unexpected response')
+        self.assertEqual(
+            search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001'][2]['value'], 'This handle is used to check if the hrls is functioning',
+            'search handle by existing key value returns unexpected response')
+        self.assertEqual(
+            search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001'][3]['type'], 'HS_ADMIN',
+            'search handle by existing key value returns unexpected response')
+        self.assertEqual(
+            len(search_result_list[str(self.prefix)+'/HRLS_CHECK_HANDLE_000001']), 4,
+            'search handle by existing key value returns unexpected response')
+
+    def test_search_handle_by_prefix_existing_key_value_6(self):
+        """Test that search by ['prefixi','URL=http://www.test_hrls_check.com/*','retrieverecords=true'] returns no handles."""
+        limit = 1000
+        search_array=['URL=http://www.test_hrls_check.com/*','retrieverecords=true']
+        search_result = execute_curl(self.handle_server_url+'/hrls/handles/'+self.prefix+'i', self.username, self.password, search_array, self.https_verify)
+        self.assertEqual(
+            search_result.status_code, 200,
+            'search hrls by existing prefixi,key value returns unexpected status')
+        self.assertEqual(
+            search_result.content, '{}',
+            'search handle by prefixi,existing key value returns unexpected response')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implement prefix as search parameter when "retrieverecords=true".
Implement testing of this functionality in automated tests
Add javax.servlet as a dependancy so maven will compile.