### PR TITLE
mysql-connector-java from 8.0.16 to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
   	<dependency>
   		<groupId>mysql</groupId>
   		<artifactId>mysql-connector-java</artifactId>
-  		<version>8.0.16</version>
+  		<version>8.0.28</version>
   	</dependency>
   	<dependency>
   		<groupId>org.apache.solr</groupId>


### PR DESCRIPTION
Updated pom.xml wiht mysql-connector-java from 8.0.16 to 8.0.28

based on https://github.com/EUDAT-B2HANDLE/B2HANDLE-HRLS/pull/78