### PR TITLE
org.eclipse.jetty:jetty-server to 9.4.51.v20230217

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.0.7.v20131107</version>  <!-- jetty 8.1.15 is used by Handle System 8 (beta) -->
+        <version>9.4.51.v20230217</version>  <!-- jetty 8.1.15 is used by Handle System 8 (beta) -->
         <configuration>
           <webAppSourceDirectory>WebContent</webAppSourceDirectory>
 		  <loginServices>


### PR DESCRIPTION
Bumps org.eclipse.jetty:jetty-server from 9.4.15.v20190215 to 9.4.51.v20230217. based on
https://github.com/EUDAT-B2HANDLE/B2HANDLE-HRLS/pull/83